### PR TITLE
Added support for tied games

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ LogWatcher.prototype.start = function () {
       }
 
       // Check if the game is over.
-      var gameOverRegex = /Entity=(.*) tag=PLAYSTATE value=(LOST|WON)$/;
+      var gameOverRegex = /Entity=(.*) tag=PLAYSTATE value=(LOST|WON|TIED)$/;
       if (gameOverRegex.test(line)) {
         var parts = gameOverRegex.exec(line);
         // Set the status for the appropriate player.


### PR DESCRIPTION
Noticed that games ending in a tie were not properly reported.  Log file shows the following:

```
[Power] GameState.DebugPrintPower() - TAG_CHANGE Entity=Tidwell tag=PLAYSTATE value=TIED

[Power] GameState.DebugPrintPower() - TAG_CHANGE Entity=The Innkeeper tag=PLAYSTATE value=TIED
```

To replicate, I used The Inkeeper on easy AI and waited to cast Hellfire when both were at 3 life.

This pull request adds support for the tied states, and properly reports the player objects from the game-over event as:

``` javascript
[{
  name: "The Innkeeper",
  status: "TIED",
  team: "OPPOSING",
  teamId: 2
},
{
  name: "Tidwell",
  status: "TIED",
  team: "FRIENDLY",
  teamId: 1
}]
```
